### PR TITLE
Readme cleaned up, migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # README
-
 Backend: Rails, Frontend: React, TypeScript, Database: Postgres
+This app uses data I collected and cleaned from my [landlord_project](https://github.com/kylemichaelreaves/landlord_data).
+I am building essentially the same app, but in Python/Django, to get a sense for the strengths and limitations of both.
+That project can be found at [django-pg-app](https://github.com/kylemichaelreaves/django-pg-app).
 
-## creating a Rails with Postgres, React, and TypeScript
+### Create a Rails with Postgres, React, and TypeScript:
 
 - `rails new [application name] -d postgresql --webpack=react`
 
-## Running this app locally requires some boilerplate:
+#### cd inside the Rails app:
+##### install Webpacker, React, TypeScript
+`bundle exec rake webpacker:install:typescript`
 
+### Running this app locally requires some boilerplate:
 - cd into the directory.
 - `touch config/boot.rb`
 - Inside of config/boot.rb, include the following:
@@ -19,26 +24,23 @@ require 'bundler/setup' # Set up gems listed in the Gemfile.
 require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
 ```
 
-- `rails webpacker:install`
-
-## Create .node-versions and .ruby-versions
-…in the project folder create two files:
+### Create .node-versions and .ruby-versions:
+In the project folder create two files:
     `touch .node-version` with `16.13.1`
     `touch .ruby-version` with `3.0.2`
+This is necessary in order to get the app to run locally.
 
-
-## Create Models
+### Create Models
 ```ruby
 rails generate model ${model}
 ```
 
-## Create db
-
+### Create db
 ```ruby
 bin/rails db:create
 ```
 
-## Make migrations
+### Make migrations
 ```ruby
 rails generate migrations AddToProperty somethingsomething, somethingelse:integer, else_array:string, array:true
 ```
@@ -46,11 +48,6 @@ rails generate migrations AddToProperty somethingsomething, somethingelse:intege
 ```ruby
 bin/rails db:migrate
 ```
-
-### Setting up React with TypeScript
-`bundle exec rake webpacker:install`
-`bundle exec rake webpacker:install:react`
-`bundle exec rake webpacker:install:typescript`
 
 ### Adding TypeScript/Webpack support
 ```

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,3 +1,3 @@
 class Property < ApplicationRecord
-    has_one :landlord
+    belongs_to :landlord
 end

--- a/db/migrate/20211210170042_changing_property_and_model_tables.rb
+++ b/db/migrate/20211210170042_changing_property_and_model_tables.rb
@@ -1,0 +1,18 @@
+class ChangingPropertyAndModelTables < ActiveRecord::Migration[6.1]
+
+  #landlords.name => properties.owner_name
+
+  def change
+    # these are not necessary in this table – they belong more to the other table
+    # the names are also potentially ambiguous; a property doesn't own properties
+    change_table :properties do |t|
+      t.remove :list_properties_owned, :number_properties_owned
+  end
+
+  # properties_io is ambiguous and problematic
+  # there can be many ids, but this assignment isn't equipped for an array of ints
+    change_table :landlords do |t|
+      t.remove :properties_id
+    end
+  end
+end

--- a/db/migrate/20211211042604_adding_references_between_property_and_landlord.rb
+++ b/db/migrate/20211211042604_adding_references_between_property_and_landlord.rb
@@ -1,0 +1,12 @@
+class AddingReferencesBetweenPropertyAndLandlord < ActiveRecord::Migration[6.1]
+  def change
+    change_table :properties do |t|
+      t.references :landlords, foreign_key: { to_table: :landlords }
+    end
+
+    change_table :landlords do |t|
+      t.integer "list_property_ids_of_owned", array: true
+    end
+
+  end
+end

--- a/db/migrate/20211211190334_removing_landlords_id_from_landlords.rb
+++ b/db/migrate/20211211190334_removing_landlords_id_from_landlords.rb
@@ -1,0 +1,7 @@
+class RemovingLandlordsIdFromLandlords < ActiveRecord::Migration[6.1]
+  def change
+    change_table :properties do |t|
+      t.remove :landlords_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_25_185105) do
+ActiveRecord::Schema.define(version: 2021_12_11_190334) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,8 +24,7 @@ ActiveRecord::Schema.define(version: 2021_11_25_185105) do
     t.string "list_properties_owned", array: true
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "properties_id", null: false
-    t.index ["properties_id"], name: "index_landlords_on_properties_id"
+    t.integer "list_property_ids_of_owned", array: true
   end
 
   create_table "properties", force: :cascade do |t|
@@ -40,13 +39,10 @@ ActiveRecord::Schema.define(version: 2021_11_25_185105) do
     t.float "longitude"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "list_properties_owned", array: true
-    t.integer "number_properties_owned"
     t.string "owner_full_mailing_address"
     t.bigint "landlord_id"
     t.index ["landlord_id"], name: "index_properties_on_landlord_id"
   end
 
-  add_foreign_key "landlords", "properties", column: "properties_id"
   add_foreign_key "properties", "landlords"
 end


### PR DESCRIPTION
Readme cleaned up. Instructions added for adding `node-versions` and `ruby-versions`. 
These are necessary for the environment to work properly and to run the app locally.

Migrations and associations added for models and their respective tables.
Properties table was bloated with columns that were more germane to the Landlords table. 
Those columns have been removed and are now present in the Landlords table. 
A column has been added for the ids—the column is set up for arrays. 