### PR TITLE
Adding the eventListener back

### DIFF
--- a/app/javascript/packs/hello_react.jsx
+++ b/app/javascript/packs/hello_react.jsx
@@ -19,9 +19,11 @@ Hello.propTypes = {
   name: PropTypes.string
 }
 
+document.addEventListener("DOMContentLoaded", () => {
+  ReactDOM.render(
+      <Hello name="React" />,
+      document.body.appendChild(document.createElement('h1'))
+    );
+  });
 
-ReactDOM.render(
-    <Hello name="React" />,
-    document.body.appendChild(document.createElement('h1'))
-  )
 


### PR DESCRIPTION
The error that the linter was throwing, which was the original reason why I deleted the eventListener, is no longer an issue for whatever reason. 