### PR TITLE
PropertyForm component fixes

### DIFF
--- a/app/javascript/components/Property/PropertyForm.tsx
+++ b/app/javascript/components/Property/PropertyForm.tsx
@@ -30,43 +30,47 @@ export default function PropertyForm({ onSave }: PropertyFormProps) {
   const [property, setProperty] = React.useState(blankProperty);
 
   return (
-    <>
-      <Form>
-        <Row>
-          <InputGroup className="mb-3">
-            <InputGroup.Text>Street Address:</InputGroup.Text>
-            <Form.Control
-              value={property.street_address}
-              onChange={(e) =>
-                setProperty({ ...property, street_address: e.target.value })
-              }
-              aria-label="street address"
-            />
-            <InputGroup.Text>Owner Name:</InputGroup.Text>
-            <Form.Control
-              value={property.owner_name}
-              onChange={(e) =>
-                setProperty({ ...property, owner_name: e.target.value })
-              }
-              aria-label="owner mailing address"
-            />
-            <Form.Control
-              value={property.owner_mailing_address}
-              onChange={(e) =>
-                setProperty({ ...property, owner_mailing_address: e.target.value })
-              }
-              aria-label="owner mailing address"
-            />
-            <Form.Control
-              value={property.city_state_zip}
-              onChange={(e) =>
-                setProperty({ ...property, city_state_zip: e.target.value })
-              }
-              aria-label="city state zip"
-            />
-          </InputGroup>
-        </Row>
-      </Form>
+    <Form>
+      <Form.Group className="mb-3" controlId="streetAddress">
+        <Form.Label>Street Address:</Form.Label>
+        <Form.Control
+          value={property.street_address}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setProperty({ ...property, street_address: e.currentTarget.value })
+          }
+          aria-label="street address"
+        />
+        <Form.Group className="mb-3" controlId="ownerName">
+          <Form.Label>Owner Name:</Form.Label>
+          <Form.Control
+            value={property.owner_name}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setProperty({ ...property, owner_name: e.currentTarget.value })
+            }
+            aria-label="owner name"
+          />
+        </Form.Group>
+        <Form.Group className="mb-3" controlId='ownerMailingAddress'>
+          <Form.Label></Form.Label>
+          <Form.Control
+            value={property.owner_mailing_address}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setProperty({ ...property, owner_mailing_address: e.currentTarget.value })
+            }
+            aria-label="owner mailing address"
+          />
+        </Form.Group>
+        <Form.Group className="mb-3" controlId="cityStateZip">
+          <Form.Label>City/State/Zipcode</Form.Label>
+          <Form.Control
+            value={property.city_state_zip}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setProperty({ ...property, city_state_zip: e.currentTarget.value })
+            }
+            aria-label="city state zip"
+          />
+        </Form.Group>
+      </Form.Group>
       <Button
         size="lg"
         onClick={() => [
@@ -77,7 +81,7 @@ export default function PropertyForm({ onSave }: PropertyFormProps) {
       >
         Save Property
       </Button>
-    </>
+    </Form>
   )
 }
 


### PR DESCRIPTION
`e` was without a type for each of the form's inputs. The correct React event type has been specified.

`Input.Group` has been changed to Form.Group. `InputGroup.Text` replaced with `Form.Label`.