### PR TITLE
Migration fixes incorrectly declared jointables

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,25 @@
 
 This app uses data from my [landlord_project](https://github.com/kylemichaelreaves/landlord_data).
 
-It's a Rails API with a React frontend. I've switched to compiling with `eslint` and `webpack` since `webpacker` has been retired. References to webacker were replaced with `yarn` and its appropriate commands. I followed [this](https://github.com/rails/jsbundling-rails/blob/main/docs/switch_from_webpacker.md) tutorial for making that switch.
+It's a Rails API with a React frontend. I've switched to compiling with `eslint` and `webpack` from `webpacker` since it
+has
+been retired. I followed [this](https://github.com/rails/jsbundling-rails/blob/main/docs/switch_from_webpacker.md)
+tutorial for making
+that switch.
 
-For general inspiration and guidance, I looked to this [tutorial](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-ruby-on-rails-project-with-a-react-frontend). However, in order to work with the latest libraries, there were some necessary modifications:
+For general inspiration and guidance, I referenced to
+this [tutorial](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-ruby-on-rails-project-with-a-react-frontend)
+. However, in order to work with the latest libraries, there were some necessary modifications:
 
-- react-router uses new syntax in v6. Moreover, in `Step 5 — Configuring React as Your Rails Frontend`, sending props in App.jsx to the routes/Index didn't work. I [this tutorial](https://reactrouter.com/docs/en/v6/getting-started/tutorial) specifically for version 6.
-- Inside of `application.html.erb` I placed a div referencing the root on the DOM, and beneath that a javascript_include_tag pointing toward the Index. In order to get the Bootstrap style to load I placed a `stylesheet_tag` beneath the generic Rails one.
-- I'm using [react-query](https://react-query.tanstack.com/) and axios to call the API data. With TypeScript, [prop and return types needed to be specified for useQuery](https://tkdodo.eu/blog/react-query-and-type-script) in order for the component to work.
+- react-router uses new syntax in v6. Moreover, in `Step 5 — Configuring React as Your Rails Frontend`, sending props in
+  App.jsx to the routes/Index didn't work.
+  I referenced [this tutorial](https://reactrouter.com/docs/en/v6/getting-started/tutorial) specifically for version 6.
+- Inside of `application.html.erb` I placed a div referencing the root on the DOM, and beneath that a
+  javascript_include_tag pointing toward the Index. In order to get the Bootstrap style to load I placed
+  a `stylesheet_tag` beneath the generic Rails one.
+- I'm using [react-query](https://react-query.tanstack.com/) and axios to call the API data. With
+  TypeScript, [prop and return types needed to be specified for useQuery](https://tkdodo.eu/blog/react-query-and-type-script)
+  in order for the component to work.
 
 This is roughly the order I followed when creating the app:
 
@@ -66,9 +78,9 @@ Use the csv module to iterate over the csv and create records:
 
 ```ruby
 require 'csv'
-    CSV.foreach("#{CSV_PATH}/jersey_city_private_property.csv", :headers => true) do |row|
-      Property.create!(row.to_hash)
-    end
+CSV.foreach("#{CSV_PATH}/jersey_city_private_property.csv", :headers => true) do |row|
+  Property.create!(row.to_hash)
+end
 ```
 
 ### Updating to the latest Rails version:
@@ -104,49 +116,56 @@ bin/rails console
 ```
 
 - Return the number of records with `Property.count`
-  ```ruby
+
+```shell
   irb(main):017:0> Property.count
   Property Count (15.4ms)  SELECT COUNT(*) FROM "properties"
   => 42030
-  ```
+ ```
+
 - Return the number of times a landlords appeared in properties: with `Property.distinct(:owner_name).count`
-  ```ruby
+
+```shell
   irb(main):021:0> Property.distinct.count(:owner_name)
   Property Count (592.1ms)  SELECT COUNT(DISTINCT "properties"."owner_name") FROM "properties"
   => 37494
-  ```
+ ```
+
 - Return an array of unique names
 
-  ```ruby
-  Property.distinct(:owner_name).pluck(:owner_name)
-  ```
+```ruby
+Property.distinct(:owner_name).pluck(:owner_name)
+```
 
-- Return an array sorted by its nested second value; the second value is the count of `owner_name` in the properties table
+- Return an array sorted by its nested second value; the second value is the count of `owner_name` in the properties
+  table
 
-  ```ruby
-  Property.pluck(:owner_name).tally.sort_by { |k, v|v }
-  ```
+```ruby
+Property.pluck(:owner_name).tally.sort_by { |k, v| v }
+```
 
 - Return distinct full (concatenated) addresses
 
-  ```ruby
-  Property.distinct.pluck(:property_full_address).count
-  ```
+```ruby
+Property.distinct.pluck(:property_full_address).count
+```
 
 - Return malformed `owner_name` (strings including more than two spaces)
 
-  ```ruby
-  Property.distinct.pluck(:owner_name).each_with_index { |el, i| puts el, i if el.match?(/\s+{2}/) }
-  ```
+```ruby
+Property.distinct.pluck(:owner_name).each_with_index { |el, i| puts el, i if el.match?(/\s+{2}/) }
+ ```
 
 - Return the id's of properties of a given owner
 
-  ```ruby
-  Property.where(owner_name: "COA 99 HUDSON,LLC").pluck(:id)
-  ```
+```ruby
+Property.where(owner_name: "COA 99 HUDSON,LLC").pluck(:id)
+ ```
 
 - Return records of Properties where Jersey City isn't in the g_code
 
 ```ruby
 Property.pluck(:g_code).uniq.select { |el| puts el if !"Jersey City".in? el }
 ```
+
+

--- a/db/migrate/20220926185754_drop_and_recreate_join_tables.rb
+++ b/db/migrate/20220926185754_drop_and_recreate_join_tables.rb
@@ -1,0 +1,23 @@
+class DropAndRecreateJoinTables < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :addresses_properties
+    drop_table :landlords_properties
+    drop_table :addresses_landlords
+
+    create_join_table :landlords, :properties do |t|
+      t.index :landlord_id
+      t.index :property_id
+    end
+
+    create_join_table :addresses, :properties do |t|
+      t.index :address_id
+      t.index :property_id
+    end
+
+    create_join_table :addresses, :landlords do |t|
+      t.index :address_id
+      t.index :landlord_id
+    end
+
+  end
+end


### PR DESCRIPTION
The Rails API documentation for [create_join_table](https://api.rubyonrails.org/v7.0.4/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-create_join_table) lets us know that we need to us block declarations if we want indices on our join-tables.